### PR TITLE
Modify bookmarkPage to duplicate, update, then remove duplicate

### DIFF
--- a/background.js
+++ b/background.js
@@ -9,12 +9,16 @@ function bookmarkPage() {
     spilloUrl += "title" + "=" + encodeURIComponent(activeTab.title);
 
     browser.tabs
-      .update({ loadReplace: true, url: spilloUrl })
-      .then(updatedTab => {
-        window.setTimeout(
-          browser.tabs.update({ loadReplace: true, url: originalUrl }),
-          100
-        );
+      .duplicate(activeTab.id)
+      .then(duplicatedTab => {
+        browser.tabs
+          .update({ loadReplace: true, url: spilloUrl })
+          .then(updatedTab => {
+            window.setTimeout(
+              browser.tabs.update({ loadReplace: true, url: originalUrl }),
+              100)
+          .then(browser.tabs.remove(duplicatedTab.id))
+        });
       });
   });
 }

--- a/background.js
+++ b/background.js
@@ -13,13 +13,8 @@ function bookmarkPage() {
       .then(duplicatedTab => {
         browser.tabs
           .update({ loadReplace: true, url: spilloUrl })
-          .then(updatedTab => {
-            window.setTimeout(
-              browser.tabs.update({ loadReplace: true, url: originalUrl }),
-              100)
           .then(browser.tabs.remove(duplicatedTab.id))
-        });
-      });
+      })
   });
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "description": "Send to Spillo Extension",
   "manifest_version": 2,
   "name": "send-to-spillo",
-  "version": "1.1",
+  "version": "1.2",
 
   "permissions": ["activeTab"],
 


### PR DESCRIPTION
Duplicates active tab, updates *the duplicate tab* with the SpilloUrl (launching Spillo's Add Bookmark window) then removes duplicate tab.

This has the effect of not modifying the active tab at all:
- Active tab doesn't reload.
- Active tab keeps its scroll position.
- Active tab stays active.