### PR TITLE
Handle the dialog that is presented on first try to communicate with …

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,23 +1,23 @@
-function bookmarkPage() {
-  browser.tabs.query({ currentWindow: true, active: true }).then(tabs => {
+function sendToSpillo() {
+  // get the active tab
+  browser.tabs.query({ currentWindow: true, active: true }).then((tabs) => {
     const activeTab = tabs[0];
-    const originalUrl = activeTab.url;
 
-    let spilloUrl = "spillo:///bookmark?";
-    spilloUrl += "url" + "=" + encodeURIComponent(activeTab.url);
-    spilloUrl += "&";
-    spilloUrl += "title" + "=" + encodeURIComponent(activeTab.title);
+    // construct the Spillo URL out of the original Tab
+    const spilloUrl = `spillo:///bookmark?url=
+    ${encodeURIComponent(activeTab.url)}
+    &title=
+    ${encodeURIComponent(activeTab.title)}`;
 
-    browser.tabs
-      .duplicate(activeTab.id)
-      .then(duplicatedTab => {
-        browser.tabs
-          .update(duplicatedTab.id, { loadReplace: true, url: spilloUrl })
-          .then(tab => 
-            window.setTimeout(_ => browser.tabs.remove(tab.id), 200)
-          )
-      });
+    // add a silent link to the document that we click
+    // to trigger the Spillo URL Handler
+    let link = document.createElement("a");
+    link.href = spilloUrl;
+    document.body.append(link);
+    link.click();
+    // and clean up after ourselves
+    link.remove();
   });
 }
 
-browser.browserAction.onClicked.addListener(bookmarkPage);
+browser.browserAction.onClicked.addListener(sendToSpillo);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "description": "Send to Spillo Extension",
   "manifest_version": 2,
   "name": "send-to-spillo",
-  "version": "1.3.1",
+  "version": "1.4",
 
   "permissions": ["activeTab"],
 


### PR DESCRIPTION
…a `spillo:///` URL

When running this extension the first time (or every time, when the user doesn't choose 'always allow' in the dialog) Firefox pops up a request if the user wants to allow the extension to communicate with the Spillo native binary.

In the current solution this will simply lead to the whole construct not working, because we're closing the tab on the user after 100ms, so they can't even see that request, much less acknowledge it.

While trying to work around that with various feature of the tabs API (all of which didn't work) I've finally realized, that we can get rid of the whole new Tab dance altogether for good and solve that problem in the same go.

So now we simply append an invisible link (invisible, because it contains no text), make the browser click it and invoke Spillo as the protocol handler that way. This also has the benefit, that the permissions dialog (if still shown) is presented in the context of the current tab, so the user can't really miss it.